### PR TITLE
Modify github.io pages to use tags from versions

### DIFF
--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -5,7 +5,7 @@ layout: default
 <article class="release release">
     <header class="release_header">
         <h1 class="release_title">{{ page.title }}</h1>
-        <p class="release_meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%A, %Y-%m-%d" }}</time></p>
+        <p class="release_meta">Release: {{ page.release_tag }}</p>
     </header>
 
     <section class="release-content">

--- a/_posts/2016-11-09-release.markdown
+++ b/_posts/2016-11-09-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 1.5-alpha-2016-11-09
 layout: release
 packages:
  -

--- a/_posts/2016-11-16-release.markdown
+++ b/_posts/2016-11-16-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 1.5-alpha-2016-11-16
 layout: release
 packages:
  -

--- a/_posts/2016-11-30-release.markdown
+++ b/_posts/2016-11-30-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 1.5-alpha-2016-11-30
 layout: release
 packages:
  -

--- a/_posts/2016-12-08-release.markdown
+++ b/_posts/2016-12-08-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 1.5-beta-2016-12-08
 layout: release
 packages:
  -

--- a/_posts/2016-12-13-release.markdown
+++ b/_posts/2016-12-13-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 1.5-2016-12-13
 layout: release
 packages:
  -

--- a/_posts/2016-12-21-release.markdown
+++ b/_posts/2016-12-21-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2016-12-21
 layout: release
 packages:
  -

--- a/_posts/2016-12-28-release.markdown
+++ b/_posts/2016-12-28-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2016-12-28
 layout: release
 packages:
  -

--- a/_posts/2017-01-04-release.markdown
+++ b/_posts/2017-01-04-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-01-04
 layout: release
 packages:
  -

--- a/_posts/2017-01-11-release.markdown
+++ b/_posts/2017-01-11-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-01-11
 layout: release
 packages:
  -

--- a/_posts/2017-01-18-release.markdown
+++ b/_posts/2017-01-18-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-01-18
 layout: release
 builds_commit: c10087b60bc66087dee9d47584426d01ffd51c98
 versions_commit: 5987bd8ef60cef770b180dfd82dc9768c0251910

--- a/_posts/2017-01-25-release.markdown
+++ b/_posts/2017-01-25-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-01-25
 layout: release
 builds_commit: 946298fa4ffbe9bd370254fe78e202eb04e4cf63
 versions_commit: 7474196dd631dcadd47199b7198052f8e5261115

--- a/_posts/2017-02-02-release.markdown
+++ b/_posts/2017-02-02-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-02-02
 layout: release
 builds_commit: f5613424ab68a6cb779320abd51c13c9312e2f67
 versions_commit: b727fb1d32b60afd5b2ac1c587521b6b36edebcc

--- a/_posts/2017-02-08-release.markdown
+++ b/_posts/2017-02-08-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-02-08
 layout: release
 builds_commit: ec8aa3da38a18e6bdb83b48a3bbdeeeb7be9aaa4
 versions_commit: 7dc1ee143cc7d6e61973900103d240d9207ab985

--- a/_posts/2017-02-15-release.markdown
+++ b/_posts/2017-02-15-release.markdown
@@ -1,5 +1,6 @@
 ---
 title: OpenPOWER Host OS release
+release_tag: 2.0-alpha-2017-02-15
 layout: release
 builds_commit: 94b1cda7d4ca0498dda51e4a34bcfbca24ba909c
 versions_commit: 2306403a4b8df04cafe51e438a883d06dcc8734f

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: OpenPOWER Host OS Builds
 <section>
     {% for post in site.posts %}
     <div class="release_listing">
-        <h2> {{ post.date | date: "%Y-%m-%d" }} release</h2>
+        <h2> {{ post.release_tag }} release</h2>
         <a href="{{ post.url | prepend: site.baseurl }}">More information</a>
     </div>
     {% endfor %}


### PR DESCRIPTION
The versions repo will have tags for each weekly build and tags for major releases. The github.io page needs to be altered to include the tag string in the pages titles.